### PR TITLE
Unify imaging conversion interfaces

### DIFF
--- a/src/clandinin_lab_to_nwb/brezovec/brezovec_convert_session.py
+++ b/src/clandinin_lab_to_nwb/brezovec/brezovec_convert_session.py
@@ -106,18 +106,10 @@ def session_to_nwb(
             "imaging_purpose": imaging_purpose,
         }
         conversion_options[interface_name] = {"stub_test": stub_test, "photon_series_index": photon_series_index}
+        if stub_test:
+            stub_frames = 5
+            conversion_options[interface_name]["stub_frames"] = stub_frames
         photon_series_index += 1
-
-    stub_frames = 5 if stub_test else None
-    if stub_frames:
-        interfaces_with_stub_frames = (
-            "ImagingFunctionalGreen",
-            "ImagingFunctionalRed",
-            "ImagingAnatomicalGreen",
-            "ImagingAnatomicalRed",
-        )
-        for interface in interfaces_with_stub_frames:
-            conversion_options[interface]["stub_frames"] = stub_frames
 
     converter = BrezovecNWBConverter(source_data=source_data, verbose=verbose)
 

--- a/src/clandinin_lab_to_nwb/brezovec/brezovec_convert_session.py
+++ b/src/clandinin_lab_to_nwb/brezovec/brezovec_convert_session.py
@@ -4,6 +4,8 @@ from typing import Union
 from datetime import datetime
 from zoneinfo import ZoneInfo
 import os
+import itertools
+
 from neuroconv.utils import load_dict_from_file, dict_deep_update
 from dateutil import parser
 
@@ -89,38 +91,33 @@ def session_to_nwb(
     source_data.update(dict(Video=dict(file_paths=file_paths)))
     conversion_options.update(dict(Video=dict(stub_test=stub_test)))
 
-    # Select correct folder for Functional Imaging
-    directory = data_dir_path / "imports" / session_id / subject_id / "func_0"
-    prefix = f"TSeries-"
-    suffix = ""
-    folder_path = find_items_in_directory(directory=directory, prefix=prefix, suffix=suffix)
+    # Determine the correct directories and add Functional and Anatomical Imaging data
+    photon_series_index = 0
+    for imaging_type, channel in itertools.product(["func_0", "anat_0"], ["Green", "Red"]):
+        directory = data_dir_path / "imports" / session_id / subject_id / imaging_type
+        folder_path = find_items_in_directory(directory=directory, prefix="TSeries-", suffix="")
+        xml_file_path = Path(folder_path) / f"{Path(folder_path).name}.xml"
 
-    xml_file_path = Path(folder_path) / f"{Path(folder_path).name}.xml"
+        imaging_purpose = "Functional" if "func" in imaging_type else "Anatomical"
+        interface_name = f"Imaging{imaging_purpose}{channel}"
+        source_data[interface_name] = {
+            "folder_path": str(folder_path),
+            "channel": channel,
+            "imaging_purpose": imaging_purpose,
+        }
+        conversion_options[interface_name] = {"stub_test": stub_test, "photon_series_index": photon_series_index}
+        photon_series_index += 1
 
-    # Add Green Channel Functional Imaging
-    source_data.update(dict(ImagingFunctionalGreen=dict(folder_path=str(folder_path), stream_name="Green")))
-    conversion_options.update(dict(ImagingFunctionalGreen=dict(stub_test=stub_test, photon_series_index=0)))
-
-    # Add Red Channel Functional Imaging
-    source_data.update(dict(ImagingFunctionalRed=dict(folder_path=str(folder_path), stream_name="Red")))
-    conversion_options.update(dict(ImagingFunctionalRed=dict(stub_test=stub_test, photon_series_index=1)))
-
-    # Select correct folder for Anatomical Imaging
-    directory = data_dir_path / "imports" / session_id / subject_id / "anat_0"
-    folder_path = find_items_in_directory(directory=directory, prefix=prefix, suffix=suffix)
-
-    # Add Green Channel Anatomical Imaging
-    source_data.update(dict(ImagingAnatomicalGreen=dict(folder_path=str(folder_path), stream_name="Green")))
-    conversion_options.update(dict(ImagingAnatomicalGreen=dict(stub_test=stub_test, photon_series_index=2)))
-
-    # Add Red Channel Anatomical Imaging
-    source_data.update(dict(ImagingAnatomicalRed=dict(folder_path=str(folder_path), stream_name="Red")))
-    conversion_options.update(dict(ImagingAnatomicalRed=dict(stub_test=stub_test, photon_series_index=3)))
-
-    stub_frames = 10 if stub_test else None
+    stub_frames = 5 if stub_test else None
     if stub_frames:
-        for key in conversion_options:
-            conversion_options[key]["stub_frames"] = stub_frames
+        interfaces_with_stub_frames = (
+            "ImagingFunctionalGreen",
+            "ImagingFunctionalRed",
+            "ImagingAnatomicalGreen",
+            "ImagingAnatomicalRed",
+        )
+        for interface in interfaces_with_stub_frames:
+            conversion_options[interface]["stub_frames"] = stub_frames
 
     converter = BrezovecNWBConverter(source_data=source_data, verbose=verbose)
 

--- a/src/clandinin_lab_to_nwb/brezovec/brezovecimagingextractor.py
+++ b/src/clandinin_lab_to_nwb/brezovec/brezovecimagingextractor.py
@@ -1,10 +1,3 @@
-"""Specialized extractor for reading NIfTI files produced via Bruker System.
-
-Classes
--------
-ScanImageTiffImagingExtractor
-    Specialized extractor for reading NIfTI files produced via Bruker System.
-"""
 from pathlib import Path
 from types import ModuleType
 from typing import Optional, Tuple, Union, List, Dict

--- a/src/clandinin_lab_to_nwb/brezovec/brezovecimaginginterface.py
+++ b/src/clandinin_lab_to_nwb/brezovec/brezovecimaginginterface.py
@@ -4,75 +4,83 @@ from clandinin_lab_to_nwb.brezovec.brezovecimagingextractor import BrezovecMulti
 from neuroconv.datainterfaces.ophys.baseimagingextractorinterface import BaseImagingExtractorInterface
 from neuroconv.utils import FolderPathType
 from neuroconv.utils.dict import DeepDict
+from typing import Literal
 
 
-class BrezovecFunctionalGreenImagingInterface(BaseImagingExtractorInterface):
+class BrezovecImagingInterface(BaseImagingExtractorInterface):
     """
-    Data Interface for writing the functional imaging data (GCaMP6f) for Clandinin lab to NWB file using BrezovecMultiPlaneImagingExtractor.
+    Data Interface for writing imaging data for the Clandinin lab to NWB file using BrezovecMultiPlaneImagingExtractor.
     """
 
     Extractor = BrezovecMultiPlaneImagingExtractor
 
-    def __init__(self, folder_path: FolderPathType, stream_name: str, verbose: bool = True):
-        """
-        Initialize reading of NIfTI files.
-
-        Parameters
-        ----------
-        folder_path : FolderPathType
-            The path to the folder that contains the NIfTI image files (.nii) and configuration files (.xml) from Bruker system.
-        stream_name: str, optional
-            The name of the recording channel.
-        verbose : bool, default: True
-        """
+    def __init__(
+        self,
+        folder_path: FolderPathType,
+        channel: Literal["Red", "Green"],
+        imaging_purpose: Literal["Functional", "Anatomical"],
+        verbose: bool = True,
+    ):
         super().__init__(
             folder_path=folder_path,
-            stream_name=stream_name,
+            stream_name=channel,
             verbose=verbose,
         )
+        self.channel = channel
+        self.imaging_purpose = imaging_purpose
 
     @classmethod
     def get_streams(cls, folder_path) -> dict:
-        streams = BrezovecMultiPlaneImagingExtractor.get_streams(folder_path=folder_path)
+        streams = cls.Extractor.get_streams(folder_path=folder_path)
         return streams
 
     def get_metadata(self) -> DeepDict:
         metadata = super().get_metadata()
-
         xml_metadata = self.imaging_extractor.xml_metadata
 
-        channel_name = "Green"
-        optical_channel_metadata = dict(
-            name=channel_name,
-            emission_lambda=513.0,
-            description="Green channel of the microscope, 525/50 nm filter.",
-        )
+        indicators = dict(Red="tdTomato", Green="GCaMP6f")
+
+        # Configure metadata according to the channel (Green/Red) and imaging_purpose (Functional/Anatomical)
+        channel_metadata = {
+            "Green": {
+                "name": "Green",
+                "emission_lambda": 513.0,
+                "description": "Green channel of the microscope, 525/50 nm filter.",
+            },
+            "Red": {
+                "name": "Red",
+                "emission_lambda": 581.0,
+                "description": "Red channel of the microscope, 550/50 nm filter.",
+            },
+        }[self.channel]
+
+        optical_channel_metadata = channel_metadata
 
         device_name = "BrukerFluorescenceMicroscope"
         metadata["Ophys"]["Device"][0].update(
             name=device_name, description=f"Bruker Ultima IV, Version {xml_metadata['version']}", manufacturer="Bruker"
         )
 
-        imaging_plane_name = "ImagingPlaneGCaMP6fFunctional"
+        indicator = indicators[self.channel]
+        imaging_plane_name = f"ImagingPlane{indicator}{self.imaging_purpose}"
         imaging_plane_metadata = metadata["Ophys"]["ImagingPlane"][0]
         imaging_plane_metadata.update(
             name=imaging_plane_name,
             optical_channel=[optical_channel_metadata],
             device=device_name,
             excitation_lambda=920.0,
-            indicator="GCaMP6f",
+            indicator=indicator,
             imaging_rate=self.imaging_extractor.get_sampling_frequency(),
         )
 
         two_photon_series_metadata = metadata["Ophys"]["TwoPhotonSeries"][0]
         two_photon_series_metadata.update(
-            name="TwoPhotonSeriesFunctionalGreen",
+            name=f"TwoPhotonSeries{self.imaging_purpose}{self.channel}",
             imaging_plane=imaging_plane_name,
             scan_line_rate=1 / float(xml_metadata["scanLinePeriod"]),
             rate=self.imaging_extractor.get_sampling_frequency(),
-            description="Imaging data acquired (GCaMP6f) from the Bruker Two-Photon Microscope and transform to NIfTI. Used for functional imaging readout",
+            description=f"{self.imaging_purpose} imaging data ({indicator}) acquired from the Bruker Two-Photon Microscope",
             unit="px",
-            # device=device_name
         )
 
         microns_per_pixel = xml_metadata["micronsPerPixel"]
@@ -97,277 +105,9 @@ class BrezovecFunctionalGreenImagingInterface(BaseImagingExtractorInterface):
 
         return metadata
 
-
-class BrezovecFunctionalRedImagingInterface(BaseImagingExtractorInterface):
-    """
-    Data Interface for writing the functional imaging data (tdTomato) for Clandinin lab to NWB file using BrezovecMultiPlaneImagingExtractor.
-
-    """
-
-    Extractor = BrezovecMultiPlaneImagingExtractor
-
-    def __init__(self, folder_path: FolderPathType, stream_name: str, verbose: bool = True):
-        """
-        Initialize reading of NIfTI files.
-
-        Parameters
-        ----------
-        folder_path : FolderPathType
-            The path to the folder that contains the NIfTI image files (.nii) and configuration files (.xml) from Bruker system.
-        stream_name: str, optional
-            The name of the recording channel.
-        verbose : bool, default: True
-        """
-        super().__init__(
-            folder_path=folder_path,
-            stream_name=stream_name,
-            verbose=verbose,
-        )
-
-    @classmethod
-    def get_streams(cls, folder_path) -> dict:
-        streams = BrezovecMultiPlaneImagingExtractor.get_streams(folder_path=folder_path)
-        return streams
-
-    def get_metadata(self) -> DeepDict:
-        metadata = super().get_metadata()
-
-        xml_metadata = self.imaging_extractor.xml_metadata
-
-        channel_name = "Red"
-        optical_channel_metadata = dict(
-            name=channel_name,
-            emission_lambda=581.0,
-            description="Red channel of the microscope, 550/50 nm filter.",
-        )
-
-        device_name = "BrukerFluorescenceMicroscope"
-        metadata["Ophys"]["Device"][0].update(
-            name=device_name, description=f"Bruker Ultima IV, Version {xml_metadata['version']}", manufacturer="Bruker"
-        )
-
-        imaging_plane_name = "ImagingPlaneTdTomatoFunctional"
-        imaging_plane_metadata = metadata["Ophys"]["ImagingPlane"][0]
-        imaging_plane_metadata.update(
-            name=imaging_plane_name,
-            optical_channel=[optical_channel_metadata],
-            device=device_name,
-            excitation_lambda=920.0,
-            indicator="tdTomato",
-            imaging_rate=self.imaging_extractor.get_sampling_frequency(),
-        )
-
-        two_photon_series_metadata = metadata["Ophys"]["TwoPhotonSeries"][0]
-        two_photon_series_metadata.update(
-            name="TwoPhotonSeriesFunctionalRed",
-            imaging_plane=imaging_plane_name,
-            scan_line_rate=1 / float(xml_metadata["scanLinePeriod"]),
-            rate=self.imaging_extractor.get_sampling_frequency(),
-            description="Imaging data acquired (tdTomato) from the Bruker Two-Photon Microscope and transform to NIfTI. Used for motion correction and registration.",  # TODO doucle check in the paper
-            unit="px",
-            # device=device_name
-        )
-
-        microns_per_pixel = xml_metadata["micronsPerPixel"]
-        if microns_per_pixel:
-            image_size_in_pixels = self.imaging_extractor.get_image_size()
-            x_position_in_meters = float(microns_per_pixel[0]["XAxis"]) / 1e6
-            y_position_in_meters = float(microns_per_pixel[1]["YAxis"]) / 1e6
-            z_plane_position_in_meters = float(microns_per_pixel[2]["ZAxis"]) / 1e6
-            grid_spacing = [y_position_in_meters, x_position_in_meters, z_plane_position_in_meters]
-
-            imaging_plane_metadata.update(grid_spacing=grid_spacing)
-
-            field_of_view = [
-                y_position_in_meters * image_size_in_pixels[1],
-                x_position_in_meters * image_size_in_pixels[0],
-                z_plane_position_in_meters * image_size_in_pixels[2],
-            ]
-            two_photon_series_metadata.update(
-                field_of_view=field_of_view, dimension=image_size_in_pixels, resolution=x_position_in_meters
-            )
-
-        return metadata
-
-
-class BrezovecAnatomicalGreenImagingInterface(BaseImagingExtractorInterface):
-    """
-    Data Interface for writing the anatomical imaging data (GCaMP6f) for Clandinin lab to NWB file using BrezovecMultiPlaneImagingExtractor.
-    """
-
-    Extractor = BrezovecMultiPlaneImagingExtractor
-
-    def __init__(self, folder_path: FolderPathType, stream_name: str, verbose: bool = True):
-        """
-        Initialize reading of NIfTI files.
-
-        Parameters
-        ----------
-        folder_path : FolderPathType
-            The path to the folder that contains the NIfTI image files (.nii) and configuration files (.xml) from Bruker system.
-        stream_name: str, optional
-            The name of the recording channel.
-        verbose : bool, default: True
-        """
-        super().__init__(
-            folder_path=folder_path,
-            stream_name=stream_name,
-            verbose=verbose,
-        )
-
-    @classmethod
-    def get_streams(cls, folder_path) -> dict:
-        streams = BrezovecMultiPlaneImagingExtractor.get_streams(folder_path=folder_path)
-        return streams
-
-    def get_metadata(self) -> DeepDict:
-        metadata = super().get_metadata()
-
-        xml_metadata = self.imaging_extractor.xml_metadata
-
-        channel_name = "Green"
-        optical_channel_metadata = dict(
-            name=channel_name,
-            emission_lambda=513.0,
-            description="Green channel of the microscope, 525/50 nm filter.",
-        )
-
-        device_name = "BrukerFluorescenceMicroscope"
-        metadata["Ophys"]["Device"][0].update(
-            name=device_name, description=f"Bruker Ultima IV, Version {xml_metadata['version']}", manufacturer="Bruker"
-        )
-
-        imaging_plane_name = "ImagingPlaneGCaMP6fAnatomical"
-        imaging_plane_metadata = metadata["Ophys"]["ImagingPlane"][0]
-        imaging_plane_metadata.update(
-            name=imaging_plane_name,
-            optical_channel=[optical_channel_metadata],
-            device=device_name,
-            excitation_lambda=920.0,
-            indicator="GCaMP6f",
-            imaging_rate=self.imaging_extractor.get_sampling_frequency(),
-        )
-
-        two_photon_series_metadata = metadata["Ophys"]["TwoPhotonSeries"][0]
-        two_photon_series_metadata.update(
-            name="TwoPhotonSeriesAnatomicalGreen",
-            imaging_plane=imaging_plane_name,
-            scan_line_rate=1 / float(xml_metadata["scanLinePeriod"]),
-            rate=self.imaging_extractor.get_sampling_frequency(),
-            description="Imaging data acquired (GCaMP6f) from the Bruker Two-Photon Microscope and transform to NIfTI. Not used",
-            unit="px",
-            # device=device_name
-        )
-
-        microns_per_pixel = xml_metadata["micronsPerPixel"]
-        if microns_per_pixel:
-            image_size_in_pixels = self.imaging_extractor.get_image_size()
-            x_position_in_meters = float(microns_per_pixel[0]["XAxis"]) / 1e6
-            y_position_in_meters = float(microns_per_pixel[1]["YAxis"]) / 1e6
-            z_plane_position_in_meters = float(microns_per_pixel[2]["ZAxis"]) / 1e6
-            grid_spacing = [y_position_in_meters, x_position_in_meters, z_plane_position_in_meters]
-
-            imaging_plane_metadata.update(grid_spacing=grid_spacing)
-
-            field_of_view = [
-                y_position_in_meters * image_size_in_pixels[1],
-                x_position_in_meters * image_size_in_pixels[0],
-                z_plane_position_in_meters * image_size_in_pixels[2],
-            ]
-
-            two_photon_series_metadata.update(
-                field_of_view=field_of_view, dimension=image_size_in_pixels, resolution=x_position_in_meters
-            )
-
-        return metadata
-
-
-class BrezovecAnatomicalRedImagingInterface(BaseImagingExtractorInterface):
-    """
-    Data Interface for writing the anatomical imaging data (tdTomato) for Clandinin lab to NWB file using BrezovecMultiPlaneImagingExtractor.
-    """
-
-    Extractor = BrezovecMultiPlaneImagingExtractor
-
-    def __init__(self, folder_path: FolderPathType, stream_name: str, verbose: bool = True):
-        """
-        Initialize reading of NIfTI files.
-
-        Parameters
-        ----------
-        folder_path : FolderPathType
-            The path to the folder that contains the NIfTI image files (.nii) and configuration files (.xml) from Bruker system.
-        stream_name: str, optional
-            The name of the recording channel.
-        verbose : bool, default: True
-        """
-        super().__init__(
-            folder_path=folder_path,
-            stream_name=stream_name,
-            verbose=verbose,
-        )
-
-    @classmethod
-    def get_streams(cls, folder_path) -> dict:
-        streams = BrezovecMultiPlaneImagingExtractor.get_streams(folder_path=folder_path)
-        return streams
-
-    def get_metadata(self) -> DeepDict:
-        metadata = super().get_metadata()
-
-        xml_metadata = self.imaging_extractor.xml_metadata
-
-        channel_name = "Red"
-        optical_channel_metadata = dict(
-            name=channel_name,
-            emission_lambda=581.0,
-            description="Red channel of the microscope, 550/50 nm filter.",
-        )
-
-        device_name = "BrukerFluorescenceMicroscope"
-        metadata["Ophys"]["Device"][0].update(
-            name=device_name, description=f"Bruker Ultima IV, Version {xml_metadata['version']}", manufacturer="Bruker"
-        )
-
-        imaging_plane_name = "ImagingPlaneTdTomatoAnatomical"
-        imaging_plane_metadata = metadata["Ophys"]["ImagingPlane"][0]
-        imaging_plane_metadata.update(
-            name=imaging_plane_name,
-            optical_channel=[optical_channel_metadata],
-            device=device_name,
-            excitation_lambda=920.0,
-            indicator="tdTomato",
-            imaging_rate=self.imaging_extractor.get_sampling_frequency(),
-        )
-
-        two_photon_series_metadata = metadata["Ophys"]["TwoPhotonSeries"][0]
-        two_photon_series_metadata.update(
-            name="TwoPhotonSeriesAnatomicalRed",
-            imaging_plane=imaging_plane_name,
-            scan_line_rate=1 / float(xml_metadata["scanLinePeriod"]),
-            rate=self.imaging_extractor.get_sampling_frequency(),
-            description="Imaging data acquired (tdTomato) from the Bruker Two-Photon Microscope and transform to NIfTI. Used for primary anatomy",  # TODO doucle check in the paper
-            unit="px",
-            # device=device_name
-        )
-
-        microns_per_pixel = xml_metadata["micronsPerPixel"]
-        if microns_per_pixel:
-            image_size_in_pixels = self.imaging_extractor.get_image_size()
-            x_position_in_meters = float(microns_per_pixel[0]["XAxis"]) / 1e6
-            y_position_in_meters = float(microns_per_pixel[1]["YAxis"]) / 1e6
-            z_plane_position_in_meters = float(microns_per_pixel[2]["ZAxis"]) / 1e6
-            grid_spacing = [y_position_in_meters, x_position_in_meters, z_plane_position_in_meters]
-
-            imaging_plane_metadata.update(grid_spacing=grid_spacing)
-
-            field_of_view = [
-                y_position_in_meters * image_size_in_pixels[1],
-                x_position_in_meters * image_size_in_pixels[0],
-                z_plane_position_in_meters * image_size_in_pixels[2],
-            ]
-            two_photon_series_metadata.update(
-                field_of_view=field_of_view, dimension=image_size_in_pixels, resolution=x_position_in_meters
-            )
-
-        return metadata
+    two_photon_series_index = {
+        "TwoPhotonSeriesFunctionalGreen": 0,
+        "TwoPhotonSeriesFunctionalRed": 1,
+        "TwoPhotonSeriesAnatomicalGreen": 2,
+        "TwoPhotonSeriesAnatomicalRed": 3,
+    }

--- a/src/clandinin_lab_to_nwb/brezovec/brezovecnwbconverter.py
+++ b/src/clandinin_lab_to_nwb/brezovec/brezovecnwbconverter.py
@@ -1,5 +1,8 @@
 """Primary NWBConverter class for this dataset."""
-from typing import Dict, List, Optional, Union
+from typing import Optional
+from neuroconv.utils.dict import DeepDict
+from datetime import datetime
+from zoneinfo import ZoneInfo
 
 from pynwb import NWBFile
 
@@ -9,6 +12,42 @@ from neuroconv.datainterfaces import (
     VideoInterface,
 )
 from .brezovecimaginginterface import BrezovecImagingInterface
+
+
+def read_session_start_time_from_file(xml_file):
+    from xml.etree import ElementTree
+    from dateutil import parser
+
+    date = None
+    first_timestamp = None
+
+    for event, elem in ElementTree.iterparse(xml_file, events=("start", "end")):
+        # Extract the date from PVScan
+        if date is None and elem.tag == "PVScan" and event == "end":
+            date_string = elem.attrib.get("date")
+            date = datetime.strptime(date_string, "%m/%d/%Y %H:%M:%S  %p")
+            elem.clear()
+
+        # Extract the time from Sequence
+        if first_timestamp is None and elem.tag == "Sequence" and event == "end":
+            sequence_time = elem.get("time")
+            first_timestamp = parser.parse(sequence_time)
+            elem.clear()
+
+        if date is not None and first_timestamp is not None:
+            break
+
+    combined_datetime = datetime(
+        date.year,
+        date.month,
+        date.day,
+        first_timestamp.hour,
+        first_timestamp.minute,
+        first_timestamp.second,
+        first_timestamp.microsecond,
+    )
+
+    return combined_datetime
 
 
 class BrezovecNWBConverter(NWBConverter):
@@ -56,7 +95,9 @@ class BrezovecNWBConverter(NWBConverter):
         from pynwb.device import Device
 
         name = "Flea FL3-U3-13E4M-C"
-        description = "Sensor used for imaging at 50 Hz with Edmund Optics 100 mm C Series Fixed Focal Length Lens"
+        description = (
+            "Sensor used for imaging with FicTrac at 50 Hz with Edmund Optics 100 mm C Series Fixed Focal Length Lens"
+        )
         manufacturer = "Teledyne FLIR Systems, Inc."
         camera_device = Device(name, description=description, manufacturer=manufacturer)
 

--- a/src/clandinin_lab_to_nwb/brezovec/brezovecnwbconverter.py
+++ b/src/clandinin_lab_to_nwb/brezovec/brezovecnwbconverter.py
@@ -8,12 +8,7 @@ from neuroconv.datainterfaces import (
     FicTracDataInterface,
     VideoInterface,
 )
-from .brezovecimaginginterface import (
-    BrezovecFunctionalGreenImagingInterface,
-    BrezovecFunctionalRedImagingInterface,
-    BrezovecAnatomicalGreenImagingInterface,
-    BrezovecAnatomicalRedImagingInterface,
-)
+from .brezovecimaginginterface import BrezovecImagingInterface
 
 
 class BrezovecNWBConverter(NWBConverter):
@@ -21,10 +16,10 @@ class BrezovecNWBConverter(NWBConverter):
 
     data_interface_classes = dict(
         FicTrac=FicTracDataInterface,
-        ImagingFunctionalGreen=BrezovecFunctionalGreenImagingInterface,
-        ImagingFunctionalRed=BrezovecFunctionalRedImagingInterface,
-        ImagingAnatomicalGreen=BrezovecAnatomicalGreenImagingInterface,
-        ImagingAnatomicalRed=BrezovecAnatomicalRedImagingInterface,
+        ImagingFunctionalGreen=BrezovecImagingInterface,
+        ImagingFunctionalRed=BrezovecImagingInterface,
+        ImagingAnatomicalGreen=BrezovecImagingInterface,
+        ImagingAnatomicalRed=BrezovecImagingInterface,
         Video=VideoInterface,
     )
 


### PR DESCRIPTION
I will also separate the interfaces as I did in https://github.com/catalystneuro/clandinin-lab-to-nwb/pull/18. That is, a nifti core with metadata specific details to this conversion on top of it. But before that, I am just condensing all the interfaces into one as it will be easier to see if something breaks.

We also had discussed this before @alessandratrapani but we skipped as low priority.