### PR TITLE
Fix path expander

### DIFF
--- a/src/clandinin_lab_to_nwb/brezovec/brezovec_convert_all_sessions.py
+++ b/src/clandinin_lab_to_nwb/brezovec/brezovec_convert_all_sessions.py
@@ -5,16 +5,20 @@ from neuroconv.tools.path_expansion import LocalPathExpander
 
 # Define rooth path and data directory
 root_path = Path.home() / "Clandinin-CN-data-share"  # Change this to the directory where the data is stored
+root_path = (
+    Path("/media/heberto/One Touch/") / "Clandinin-CN-data-share"
+)  # Change this to the directory where the data is stored
 data_dir_path = root_path / "brezovec_example_data"
 output_dir_path = Path.home() / "conversion_nwb"
-stub_test = False  # Set to False to convert the full session otherwise only a stub will be converted for testing
+stub_test = True  # Set to False to convert the full session otherwise only a stub will be converted for testing
 verbose = True
 
 # Specify source data (note this assumes the files are arranged in the same way as in the example data)
+base_directory = data_dir_path
 source_data_spec = {
-    "imaging_function": {
-        "base_directory": data_dir_path / "imports",
-        "folder_path": "{session_id}/{subject_id}/func_0/TSeries-{session_start_time:%m%d%Y}-{other}/TSeries-{session_start_time:%m%d%Y}-{other}.xml",
+    "imaging": {
+        "base_directory": base_directory,
+        "folder_path": "imports/{session_id}/{subject_id}",
     }
 }
 
@@ -24,7 +28,18 @@ path_expander = LocalPathExpander()
 # Expand paths and extract metadata
 metadata_list = path_expander.expand_paths(source_data_spec)
 
-# Print the results
+# Filter dor directories that exist and are named "fly" to get the metadata for each session
+metadata_list = [
+    metadata_match
+    for metadata_match in metadata_list
+    if Path(metadata_match["source_data"]["imaging"]["folder_path"]).is_dir()
+]
+metadata_list = [
+    metadata_match
+    for metadata_match in metadata_list
+    if "fly" in Path(metadata_match["source_data"]["imaging"]["folder_path"]).name
+]
+
 for metadata in metadata_list:
     session_to_nwb(
         data_dir_path=data_dir_path,

--- a/src/clandinin_lab_to_nwb/brezovec/brezovec_convert_session.py
+++ b/src/clandinin_lab_to_nwb/brezovec/brezovec_convert_session.py
@@ -1,18 +1,13 @@
 """Primary script to run to convert an entire session for of data using the NWBConverter."""
 from pathlib import Path
 from typing import Union
-import os
 import itertools
+from zoneinfo import ZoneInfo
 
 from neuroconv.utils import load_dict_from_file, dict_deep_update
 
 from clandinin_lab_to_nwb.brezovec import BrezovecNWBConverter
-
-
-def find_items_in_directory(directory: str, prefix: str, suffix: str):
-    for item in os.listdir(directory):
-        if item.startswith(prefix) and item.endswith(suffix):
-            return os.path.join(directory, item)
+from clandinin_lab_to_nwb.brezovec.brezovecimaginginterface import BrezovecImagingInterface
 
 
 def session_to_nwb(
@@ -37,29 +32,15 @@ def session_to_nwb(
     source_data = dict()
     conversion_options = dict()
 
-    # Add Fictrac
-    directory = data_dir_path / "fictrac"
-    prefix = f"fictrac-{session_id}"
-    suffix = ".dat"
-    file_path = find_items_in_directory(directory=directory, prefix=prefix, suffix=suffix)
-    diameter_mm = 9.0  # From the Brezovec paper
-    diameter_meters = diameter_mm / 1000.0
-    source_data.update(dict(FicTrac=dict(file_path=str(file_path), radius=diameter_meters / 2)))
-
-    # Video
-    suffix = "-raw.avi"
-    file_path = find_items_in_directory(directory=directory, prefix=prefix, suffix=suffix)
-    file_paths = [file_path]
-    source_data.update(dict(Video=dict(file_paths=file_paths)))
-    conversion_options.update(dict(Video=dict(stub_test=stub_test)))
-
     # Determine the correct directories and add Functional and Anatomical Imaging data
     photon_series_index = 0
+    imaging_purpose_mapping = dict(func_0="Functional", anat_0="Anatomical")
     for imaging_type, channel in itertools.product(["func_0", "anat_0"], ["Green", "Red"]):
         directory = data_dir_path / "imports" / session_id / subject_id / imaging_type
-        folder_path = find_items_in_directory(directory=directory, prefix="TSeries-", suffix="")
+        imaging_folders_in_directory = (path for path in directory.iterdir() if path.is_dir())
+        folder_path = next(path for path in imaging_folders_in_directory if "TSeries" in path.name)
 
-        imaging_purpose = "Functional" if "func" in imaging_type else "Anatomical"
+        imaging_purpose = imaging_purpose_mapping[imaging_type]
         interface_name = f"Imaging{imaging_purpose}{channel}"
         source_data[interface_name] = {
             "folder_path": str(folder_path),
@@ -72,6 +53,29 @@ def session_to_nwb(
             conversion_options[interface_name]["stub_frames"] = stub_frames
         photon_series_index += 1
 
+    # Get the session start time from the Functional Green imaging data
+    folder_path = source_data["ImagingFunctionalGreen"]["folder_path"]
+    xml_file_path = Path(folder_path) / f"{Path(folder_path).name}.xml"
+    functional_imaging_datetime = BrezovecImagingInterface.read_session_start_time_from_file(xml_file_path)
+    hours_minutes_string = functional_imaging_datetime.strftime("%H%M")
+
+    # Add Fictrac
+    fictrac_directory = data_dir_path / "fictrac"
+    fictrac_files = (path for path in fictrac_directory.iterdir() if path.suffix == ".dat")
+    pattern = f"fictrac-{session_id}_{hours_minutes_string}"
+    fictrac_file_path = [path for path in fictrac_files if pattern in path.name]
+    assert len(fictrac_file_path) == 1, f"Expected to find a single FicTrac file with pattern {pattern}"
+    fictrac_file_path = fictrac_file_path[0]
+    diameter_mm = 9.0  # From the Brezovec paper
+    diameter_meters = diameter_mm / 1000.0
+    source_data.update(dict(FicTrac=dict(file_path=str(fictrac_file_path), radius=diameter_meters / 2)))
+
+    # Video
+    video_file_path = fictrac_file_path.with_name(fictrac_file_path.stem + "-raw.avi")
+    file_paths = [video_file_path]
+    source_data.update(dict(Video=dict(file_paths=file_paths)))
+    conversion_options.update(dict(Video=dict(stub_test=stub_test)))
+
     converter = BrezovecNWBConverter(source_data=source_data, verbose=verbose)
 
     metadata = converter.get_metadata()
@@ -81,8 +85,11 @@ def session_to_nwb(
     editable_metadata = load_dict_from_file(editable_metadata_path)
     metadata = dict_deep_update(metadata, editable_metadata)
 
-    # Add the correct subject ID
-    metadata = dict_deep_update(metadata, {"Subject": {"subject_id": subject_id}})
+    # Add the correct metadata for the session
+    timezone = ZoneInfo("America/Los_Angeles")  # Time zone for Stanford, California
+    session_start_time = functional_imaging_datetime.replace(tzinfo=timezone)
+    metadata["NWBFile"]["session_start_time"] = session_start_time
+    metadata["Subject"]["subject_id"] = subject_id
 
     # Run conversion
     converter.run_conversion(
@@ -98,6 +105,7 @@ if __name__ == "__main__":
     from clandinin_lab_to_nwb.brezovec.brezovec_convert_session import session_to_nwb
 
     root_path = Path.home() / "Clandinin-CN-data-share"  # Change this to the directory where the data is stored
+    root_path = Path("/media/heberto/One Touch/Clandinin-CN-data-share")
     data_dir_path = root_path / "brezovec_example_data"
     output_dir_path = Path.home() / "conversion_nwb"
     stub_test = True  # Set to False to convert the full session

--- a/src/clandinin_lab_to_nwb/brezovec/brezovecimaginginterface.py
+++ b/src/clandinin_lab_to_nwb/brezovec/brezovecimaginginterface.py
@@ -93,7 +93,7 @@ class BrezovecImagingInterface(BaseImagingExtractorInterface):
             pixel_size_in_meters_z = float(microns_per_pixel[2]["ZAxis"]) / 1e6
             grid_spacing = [pixel_size_in_meters_y, pixel_size_in_meters_x, pixel_size_in_meters_z]
 
-            imaging_plane_metadata.update(grid_spacing=grid_spacing, grid_spacing_units="meters")
+            imaging_plane_metadata.update(grid_spacing=grid_spacing, grid_spacing_unit="meters")
 
             image_size_in_pixels = self.imaging_extractor.get_image_size()
 
@@ -136,7 +136,7 @@ class BrezovecImagingInterface(BaseImagingExtractorInterface):
             # Extract the date from PVScan
             if date is None and elem.tag == "PVScan" and event == "end":
                 date_string = elem.attrib.get("date")
-                date = datetime.strptime(date_string, "%m/%d/%Y %H:%M:%S  %p")
+                date = datetime.strptime(date_string, "%m/%d/%Y %I:%M:%S %p")
                 elem.clear()
 
             # Extract the time from Sequence

--- a/src/clandinin_lab_to_nwb/brezovec/brezovecimaginginterface.py
+++ b/src/clandinin_lab_to_nwb/brezovec/brezovecimaginginterface.py
@@ -1,5 +1,7 @@
 from dateutil.parser import parse
 from clandinin_lab_to_nwb.brezovec.brezovecimagingextractor import BrezovecMultiPlaneImagingExtractor
+from pathlib import Path
+from datetime import datetime
 
 from neuroconv.datainterfaces.ophys.baseimagingextractorinterface import BaseImagingExtractorInterface
 from neuroconv.utils import FolderPathType
@@ -28,6 +30,7 @@ class BrezovecImagingInterface(BaseImagingExtractorInterface):
         )
         self.channel = channel
         self.imaging_purpose = imaging_purpose
+        self.folder_path = folder_path
 
     @classmethod
     def get_streams(cls, folder_path) -> dict:
@@ -68,7 +71,7 @@ class BrezovecImagingInterface(BaseImagingExtractorInterface):
             name=imaging_plane_name,
             optical_channel=[optical_channel_metadata],
             device=device_name,
-            excitation_lambda=920.0,
+            excitation_lambda=920.0,  #   Chameleon Vision II femtosecond laser (Coherent) at 920 nm.
             indicator=indicator,
             imaging_rate=self.imaging_extractor.get_sampling_frequency(),
         )
@@ -79,28 +82,29 @@ class BrezovecImagingInterface(BaseImagingExtractorInterface):
             imaging_plane=imaging_plane_name,
             scan_line_rate=1 / float(xml_metadata["scanLinePeriod"]),
             rate=self.imaging_extractor.get_sampling_frequency(),
-            description=f"{self.imaging_purpose} imaging data ({indicator}) acquired from the Bruker Two-Photon Microscope",
-            unit="px",
+            description=f"{self.imaging_purpose} imaging data ({indicator})",
+            unit="voxels",
         )
 
         microns_per_pixel = xml_metadata["micronsPerPixel"]
         if microns_per_pixel:
-            image_size_in_pixels = self.imaging_extractor.get_image_size()
-            x_position_in_meters = float(microns_per_pixel[0]["XAxis"]) / 1e6
-            y_position_in_meters = float(microns_per_pixel[1]["YAxis"]) / 1e6
-            z_plane_position_in_meters = float(microns_per_pixel[2]["ZAxis"]) / 1e6
-            grid_spacing = [y_position_in_meters, x_position_in_meters, z_plane_position_in_meters]
+            pixel_size_in_meters_x = float(microns_per_pixel[0]["XAxis"]) / 1e6
+            pixel_size_in_meters_y = float(microns_per_pixel[1]["YAxis"]) / 1e6
+            pixel_size_in_meters_z = float(microns_per_pixel[2]["ZAxis"]) / 1e6
+            grid_spacing = [pixel_size_in_meters_y, pixel_size_in_meters_x, pixel_size_in_meters_z]
 
-            imaging_plane_metadata.update(grid_spacing=grid_spacing)
+            imaging_plane_metadata.update(grid_spacing=grid_spacing, grid_spacing_units="meters")
+
+            image_size_in_pixels = self.imaging_extractor.get_image_size()
 
             field_of_view = [
-                y_position_in_meters * image_size_in_pixels[1],
-                x_position_in_meters * image_size_in_pixels[0],
-                z_plane_position_in_meters * image_size_in_pixels[2],
+                pixel_size_in_meters_y * image_size_in_pixels[1],
+                pixel_size_in_meters_x * image_size_in_pixels[0],
+                pixel_size_in_meters_z * image_size_in_pixels[2],
             ]
 
             two_photon_series_metadata.update(
-                field_of_view=field_of_view, dimension=image_size_in_pixels, resolution=x_position_in_meters
+                field_of_view=field_of_view, dimension=image_size_in_pixels, resolution=pixel_size_in_meters_x
             )
 
         return metadata
@@ -111,3 +115,47 @@ class BrezovecImagingInterface(BaseImagingExtractorInterface):
         "TwoPhotonSeriesAnatomicalGreen": 2,
         "TwoPhotonSeriesAnatomicalRed": 3,
     }
+
+    def get_series_datetime(self):
+        folder_path = Path(self.folder_path)
+        xml_file_path = folder_path / f"{folder_path.name}.xml"
+        assert xml_file_path.is_file(), f"The XML configuration file is not found at '{folder_path}'."
+
+        series_datetime = self.read_session_start_time_from_file(xml_file_path)
+        return series_datetime
+
+    @staticmethod
+    def read_session_start_time_from_file(xml_file_path):
+        from xml.etree import ElementTree
+        from dateutil import parser
+
+        date = None
+        first_timestamp = None
+
+        for event, elem in ElementTree.iterparse(xml_file_path, events=("start", "end")):
+            # Extract the date from PVScan
+            if date is None and elem.tag == "PVScan" and event == "end":
+                date_string = elem.attrib.get("date")
+                date = datetime.strptime(date_string, "%m/%d/%Y %H:%M:%S  %p")
+                elem.clear()
+
+            # Extract the time from Sequence
+            if first_timestamp is None and elem.tag == "Sequence" and event == "end":
+                sequence_time = elem.get("time")
+                first_timestamp = parser.parse(sequence_time)
+                elem.clear()
+
+            if date is not None and first_timestamp is not None:
+                break
+
+        combined_datetime = datetime(
+            date.year,
+            date.month,
+            date.day,
+            first_timestamp.hour,
+            first_timestamp.minute,
+            first_timestamp.second,
+            first_timestamp.microsecond,
+        )
+
+        return combined_datetime

--- a/src/clandinin_lab_to_nwb/brezovec/brezovecnwbconverter.py
+++ b/src/clandinin_lab_to_nwb/brezovec/brezovecnwbconverter.py
@@ -27,20 +27,6 @@ class BrezovecNWBConverter(NWBConverter):
         Video=VideoInterface,
     )
 
-    def get_metadata(self) -> DeepDict:
-        metadata = super().get_metadata()
-
-        # Add datetime to conversion from the Functional Green imaging data
-        folder_path = self.data_interface_objects["ImagingFunctionalGreen"].folder_path
-        xml_file_path = Path(folder_path) / f"{Path(folder_path).name}.xml"
-
-        functional_imaging_datetime = BrezovecImagingInterface.read_session_start_time_from_file(xml_file_path)
-        timezone = ZoneInfo("America/Los_Angeles")  # Time zone for Stanford, California
-        session_start_time = functional_imaging_datetime.replace(tzinfo=timezone)
-        metadata["NWBFile"]["session_start_time"] = session_start_time
-
-        return super().get_metadata()
-
     def temporally_align_data_interfaces(self):
         fictrac_interface = self.data_interface_objects["FicTrac"]
         video_interface = self.data_interface_objects["Video"]

--- a/src/clandinin_lab_to_nwb/brezovec/brezovecnwbconverter.py
+++ b/src/clandinin_lab_to_nwb/brezovec/brezovecnwbconverter.py
@@ -42,29 +42,32 @@ class BrezovecNWBConverter(NWBConverter):
         return super().get_metadata()
 
     def temporally_align_data_interfaces(self):
+        fictrac_interface = self.data_interface_objects["FicTrac"]
+        video_interface = self.data_interface_objects["Video"]
         functional_green_interface = self.data_interface_objects["ImagingFunctionalGreen"]
         functional_red_interface = self.data_interface_objects["ImagingFunctionalRed"]
         anatomical_green_interface = self.data_interface_objects["ImagingAnatomicalGreen"]
         anatomical_red_interface = self.data_interface_objects["ImagingAnatomicalRed"]
 
-        session_start_time = functional_green_interface.imaging_extractor.get_series_datetime()
-        UTC_session_start_time = session_start_time.timestamp()
-        aligned_starting_time = 0.0
-        functional_green_interface.set_aligned_starting_time(aligned_starting_time)
+        # As the authors we create a timestamps for the FicTrac as if they have uniform sampling rate
+        sampling_rate = 50  # Hz
+        num_samples = fictrac_interface.get_original_timestamps().size
+        duration = num_samples / sampling_rate
 
-        series_start_time = functional_red_interface.imaging_extractor.get_series_datetime()
-        UTC_series_start_time = series_start_time.timestamp()
-        aligned_starting_time = UTC_series_start_time - UTC_session_start_time
-        functional_red_interface.set_aligned_starting_time(aligned_starting_time)
+        unifom_timestamps = np.linspace(0, duration, num_samples, endpoint=False)
 
-        series_start_time = anatomical_green_interface.imaging_extractor.get_series_datetime()
-        UTC_series_start_time = series_start_time.timestamp()
-        aligned_starting_time = UTC_series_start_time - UTC_session_start_time
+        fictrac_interface.set_aligned_timestamps(unifom_timestamps)
+        video_interface.set_aligned_timestamps([unifom_timestamps])
+
+        # The functional imaging is already aligned but we need to shift the anatomical imaging
+        # Note that both channels start at the same time
+        functional_datetime = functional_green_interface.get_series_datetime()
+        functional_timestamp = functional_datetime.timestamp()
+
+        anatomy_datetime = anatomical_green_interface.get_series_datetime()
+        anatomy_timestamp = anatomy_datetime.timestamp()
+        aligned_starting_time = anatomy_timestamp - functional_timestamp
         anatomical_green_interface.set_aligned_starting_time(aligned_starting_time)
-
-        series_start_time = anatomical_red_interface.imaging_extractor.get_series_datetime()
-        UTC_series_start_time = series_start_time.timestamp()
-        aligned_starting_time = UTC_series_start_time - UTC_session_start_time
         anatomical_red_interface.set_aligned_starting_time(aligned_starting_time)
 
     def add_to_nwbfile(self, nwbfile: NWBFile, metadata, conversion_options: Optional[dict] = None) -> None:


### PR DESCRIPTION
Now that we have the full data the old path expansion scheme was not working. I needed to do some changes to account for that as the fictract files can only be disambiguate with the full session start time that I was extracting at the metadata level so I had to revert that to have it on the script again : /